### PR TITLE
added/ auth logout using jwt_tokens table

### DIFF
--- a/app/Actions/Auth/CreateJwtTokenAction.php
+++ b/app/Actions/Auth/CreateJwtTokenAction.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Actions\Auth;
+
+use App\Exceptions\Auth\UnauthorizedException;
+use App\Models\User;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\Log;
+
+class CreateJwtTokenAction
+{
+    /**
+     * Execute the action.
+     * @param User $user
+     * @param string $unique_id
+     * @param array|null $restrictions
+     * @param array|null $permission
+     * @param CarbonInterface $expire_at
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function execute(User $user, string $unique_id, array $restrictions = null, array $permission = null,  CarbonInterface $expire_at)
+    {
+        try {
+            return $this->createJwtToken($user, $unique_id, $restrictions, $permission, $expire_at);
+        } catch (\Throwable $e) {
+            Log::error($e->getMessage());
+            throw new UnauthorizedException('Unable to create JWT token');
+        }
+    }
+
+    /**
+     * Create a JWT token.
+     * @param User $user
+     * @param string $unique_id
+     * @param array|null $restrictions
+     * @param array|null $permission
+     * @param CarbonInterface $expire_at
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    private function createJwtToken(User $user, string $unique_id, array $restrictions = null, array $permission = null,  CarbonInterface $expire_at)
+    {
+        return $user->jwtTokens()->create([
+            'unique_id' => $unique_id,
+            'expires_at' => Carbon::parse($expire_at),
+            'token_title' => 'Token for ' . $user->uuid,
+            'restrictions' => $restrictions,
+            'permissions' => $permission,
+        ]);
+    }
+}

--- a/app/Models/JwtTokens.php
+++ b/app/Models/JwtTokens.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JwtTokens extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'user_id',
+        'unique_id',
+        'token_title',
+        'restrictions',
+        'permissions',
+        'expires_at',
+        'last_used_at',
+        'refreshed_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'restrictions' => 'array',
+        'permissions' => 'array',
+        'expires_at' => 'datetime',
+        'last_used_at' => 'datetime',
+        'refreshed_at' => 'datetime',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'expires_at',
+        'last_used_at',
+        'refreshed_at',
+    ];
+
+    /**
+     * Get the user that owns the token.
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -68,6 +68,15 @@ class User extends Authenticatable
     }
 
     /**
+     * Get the user jwt tokens.
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function jwtTokens()
+    {
+        return $this->hasMany(JwtTokens::class);
+    }
+
+    /**
      * Instantiate a new QueryBuilder instance.
      */
     public function newEloquentBuilder($query): UserBuilder

--- a/app/Repositories/Admin/Auth/AuthenticateRepository.php
+++ b/app/Repositories/Admin/Auth/AuthenticateRepository.php
@@ -60,7 +60,7 @@ class AuthenticateRepository implements AdminAuthenticateRepositoryInterface
      */
     public function logout()
     {
-        Auth::logout();
+        $this->authAction->logout();
     }
 
     /**

--- a/app/Repositories/User/Auth/AuthenticateRepository.php
+++ b/app/Repositories/User/Auth/AuthenticateRepository.php
@@ -89,7 +89,7 @@ class AuthenticateRepository implements AuthenticateUserRepositoryInterface
      */
     public function logout()
     {
-        Auth::logout();
+        $this->authAction->logout();
     }
 
     /**

--- a/app/Services/JWT/JwtGuard.php
+++ b/app/Services/JWT/JwtGuard.php
@@ -2,10 +2,12 @@
 
 namespace App\Services\JWT;
 
+use App\Models\JwtTokens;
 use Illuminate\Auth\GuardHelpers;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class JwtGuard implements Guard
 {
@@ -77,7 +79,11 @@ class JwtGuard implements Guard
 
         try {
             $decoded = $this->authenticatedAccessToken($token);
-
+            Log::info('tokenIsInvalidated: ' . $this->tokenIsInvalidated($decoded->getIdentifiedBy()));
+            if (!$this->tokenIsInvalidated($decoded->getIdentifiedBy())) {
+                return null;
+            }
+            
             if (!$decoded) {
                 $user = null;
             } else {
@@ -99,5 +105,10 @@ class JwtGuard implements Guard
     protected function hasValidCredentials($user, $credentials)
     {
         return $user !== null && $this->provider->validateCredentials($user, $credentials);
+    }
+
+    protected function tokenIsInvalidated(string $identifyBy): bool
+    {
+        return JwtTokens::where('unique_id', $identifyBy)->exists();
     }
 }


### PR DESCRIPTION
### Description
I have implemented the logout feature by using table jwt_tokens to store all the JWT tokens generated for the users. The `jwt_tokens` table has columns like `id`, `user_id`, `unique_id`, `permission`, `restrictions`, `expired_at`, and `last_used_at`.

To handle the logout functionality, I have added a new method named tokenIsInvalidated() to the JwtGuard class. This method allows the invalidation of specific tokens of a user using `unique_id` in the jwt_tokens table. I have also added a new method named invalidateToken() to the JwtGuard class to invalidate a specific token of a user in the jwt_tokens table.

I have also added `CreateJwtTokenAction` class to handle adding created token to the `jwt_tokens` table