### PR TITLE
refactor/ using BaseRequest for same rule application

### DIFF
--- a/app/Http/Requests/Admin/User/UserListingRequest.php
+++ b/app/Http/Requests/Admin/User/UserListingRequest.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\Requests\Admin\User;
 
+use App\Http\Requests\BaseRequest;
 use Illuminate\Foundation\Http\FormRequest;
 
-class UserListingRequest extends FormRequest
+class UserListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,17 +22,13 @@ class UserListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
+        return array_merge(parent::rules(), [
             'first_name' => 'nullable|string',
             'email' => 'nullable|string',
             'phone' => 'nullable|string',
             'address' => 'nullable|string',
             'created_at' => 'nullable|string|date_format:Y-m-d',
             'marketing' => 'nullable|string',
-        ];
+        ]);
     }
 }

--- a/app/Http/Requests/BaseRequest.php
+++ b/app/Http/Requests/BaseRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BaseRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'page' => 'nullable|integer',
+            'limit' => 'nullable|integer',
+            'sortBy' => 'nullable|string',
+            'desc' => 'nullable|boolean',
+        ];
+    }
+}

--- a/app/Http/Requests/User/Blog/BlogListingRequest.php
+++ b/app/Http/Requests/User/Blog/BlogListingRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\User\Blog;
 
-use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\BaseRequest;
 
-class BlogListingRequest extends FormRequest
+class BlogListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,11 +21,8 @@ class BlogListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
-        ];
+        return array_merge(parent::rules(), [
+            // additional rules specific to this request
+        ]);
     }
 }

--- a/app/Http/Requests/User/Brand/BrandListingRequest.php
+++ b/app/Http/Requests/User/Brand/BrandListingRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\User\Brand;
 
-use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\BaseRequest;
 
-class BrandListingRequest extends FormRequest
+class BrandListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,11 +21,8 @@ class BrandListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
-        ];
+        return array_merge(parent::rules(), [
+            // additional rules specific to this request
+        ]);
     }
 }

--- a/app/Http/Requests/User/Category/CategoryListingRequest.php
+++ b/app/Http/Requests/User/Category/CategoryListingRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\User\Category;
 
-use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\BaseRequest;
 
-class CategoryListingRequest extends FormRequest
+class CategoryListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,11 +21,8 @@ class CategoryListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
-        ];
+        return array_merge(parent::rules(), [
+            // additional rules specific to this request
+        ]);
     }
 }

--- a/app/Http/Requests/User/Order/OrderListingRequest.php
+++ b/app/Http/Requests/User/Order/OrderListingRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\User\Order;
 
-use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\BaseRequest;
 
-class OrderListingRequest extends FormRequest
+class OrderListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,11 +21,8 @@ class OrderListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
-        ];
+        return array_merge(parent::rules(), [
+            // additional rules specific to this request
+        ]);
     }
 }

--- a/app/Http/Requests/User/Order/OrderPopulateRequest.php
+++ b/app/Http/Requests/User/Order/OrderPopulateRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\User\Order;
 
-use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\BaseRequest;
 
-class OrderPopulateRequest extends FormRequest
+class OrderPopulateRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,15 +21,11 @@ class OrderPopulateRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
+        return array_merge(parent::rules(), [
             'dateRange' => 'nullable|array',
             'dateRange.from' => 'nullable|date|before_or_equal:dateRange.to',
             'dateRange.to' => 'nullable|date|after_or_equal:dateRange.from',
             'fixRange' => 'nullable|in:today,monthly,yearly',
-        ];
+        ]);
     }
 }

--- a/app/Http/Requests/User/Order/OrderShippingListingRequest.php
+++ b/app/Http/Requests/User/Order/OrderShippingListingRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\User\Order;
 
-use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\BaseRequest;
 
-class OrderShippingListingRequest extends FormRequest
+class OrderShippingListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,17 +21,13 @@ class OrderShippingListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
+        return array_merge(parent::rules(), [
             'dateRange' => 'nullable|array',
             'dateRange.from' => 'nullable|date|before_or_equal:dateRange.to',
             'dateRange.to' => 'nullable|date|after_or_equal:dateRange.from',
             'fixRange' => 'nullable|in:today,monthly,yearly',
             'orderUuid' => 'nullable|string|exists:orders,uuid',
             'customerUuid' => 'nullable|string|exists:users,uuid',
-        ];
+        ]);
     }
 }

--- a/app/Http/Requests/User/Order/OrderStatusListingRequest.php
+++ b/app/Http/Requests/User/Order/OrderStatusListingRequest.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\Requests\User\Order;
 
+use App\Http\Requests\BaseRequest;
 use Illuminate\Foundation\Http\FormRequest;
 
-class OrderStatusListingRequest extends FormRequest
+class OrderStatusListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,11 +22,8 @@ class OrderStatusListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
-        ];
+        return array_merge(parent::rules(), [
+            // additional rules specific to this request
+        ]);
     }
 }

--- a/app/Http/Requests/User/Payment/PaymentListingRequest.php
+++ b/app/Http/Requests/User/Payment/PaymentListingRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\User\Payment;
 
-use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\BaseRequest;
 
-class PaymentListingRequest extends FormRequest
+class PaymentListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,11 +21,8 @@ class PaymentListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
-        ];
+        return array_merge(parent::rules(), [
+            // additional rules specific to this request
+        ]);
     }
 }

--- a/app/Http/Requests/User/Product/ProductListingRequest.php
+++ b/app/Http/Requests/User/Product/ProductListingRequest.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\Requests\User\Product;
 
+use App\Http\Requests\BaseRequest;
 use Illuminate\Foundation\Http\FormRequest;
 
-class ProductListingRequest extends FormRequest
+class ProductListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,11 +22,8 @@ class ProductListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
-        ];
+        return array_merge(parent::rules(), [
+            // additional rules specific to this request
+        ]);
     }
 }

--- a/app/Http/Requests/User/Promotion/PromotionListingRequest.php
+++ b/app/Http/Requests/User/Promotion/PromotionListingRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\User\Promotion;
 
-use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Requests\BaseRequest;
 
-class PromotionListingRequest extends FormRequest
+class PromotionListingRequest extends BaseRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,11 +21,8 @@ class PromotionListingRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'page' => 'nullable|integer',
-            'limit' => 'nullable|integer',
-            'sortBy' => 'nullable|string',
-            'desc' => 'nullable|boolean',
-        ];
+        return array_merge(parent::rules(), [
+            // additional rules specific to this request
+        ]);
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Builders\Post\PostBuilder;
+use App\Traits\HasImage;
 use App\Traits\Sluggable;
 use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -10,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    use HasFactory, Uuids, Sluggable;
+    use HasFactory, Uuids, Sluggable, HasImage;
 
     /**
      * The attributes that are mass assignable.
@@ -33,25 +34,6 @@ class Post extends Model
     protected $casts = [
         'metadata' => 'array',
     ];
-
-    /**
-     * Get the image uuid of the metadata attribute.
-     * @return string
-     */
-    public function getImageUuidAttribute(): string
-    {
-        return $this->metadata['image'];
-    }
-
-    /**
-     * Get the related image.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function image()
-    {
-        return $this->belongsTo(File::class, 'image_uuid', 'uuid');
-    }
 
     /**
      * Instantiate a new QueryBuilder instance.

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Builders\Product\ProductBuilder;
+use App\Traits\HasImage;
 use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -10,7 +11,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Product extends Model
 {
-    use HasFactory, Uuids, SoftDeletes;
+    use HasFactory, Uuids, HasImage, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.
@@ -62,15 +63,6 @@ class Product extends Model
     }
 
     /**
-     * Get the image uuid of the metadata attribute.
-     * @return string
-     */
-    public function getImageUuidAttribute(): string
-    {
-        return $this->metadata['image'];
-    }
-
-    /**
      * Get the related brand.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
@@ -78,16 +70,6 @@ class Product extends Model
     public function brand()
     {
         return $this->belongsTo(Brand::class, 'brand_uuid', 'uuid');
-    }
-
-    /**
-     * Get the related image.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function image()
-    {
-        return $this->belongsTo(File::class, 'image_uuid', 'uuid');
     }
 
     /**

--- a/app/Models/Promotion.php
+++ b/app/Models/Promotion.php
@@ -3,13 +3,14 @@
 namespace App\Models;
 
 use App\Builders\Promotion\PromotionBuilder;
+use App\Traits\HasImage;
 use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Promotion extends Model
 {
-    use HasFactory, Uuids;
+    use HasFactory, Uuids, HasImage;
 
     /**
      * The attributes that are mass assignable.
@@ -31,25 +32,6 @@ class Promotion extends Model
     protected $casts = [
         'metadata' => 'array',
     ];
-
-    /**
-     * Get the image uuid of the metadata attribute.
-     * @return string
-     */
-    public function getImageUuidAttribute(): string
-    {
-        return $this->metadata['image'];
-    }
-
-    /**
-     * Get the related image.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function image()
-    {
-        return $this->belongsTo(File::class, 'image_uuid', 'uuid');
-    }
 
     /**
      * Instantiate a new QueryBuilder instance.

--- a/app/Repositories/User/Auth/AuthenticateRepository.php
+++ b/app/Repositories/User/Auth/AuthenticateRepository.php
@@ -11,6 +11,7 @@ use App\Exceptions\User\UserNotFoundException;
 use App\Models\User;
 use App\Traits\HttpResponse;
 use Carbon\Carbon;
+use Firebase\JWT\JWT;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Auth;
 

--- a/app/Traits/HasImage.php
+++ b/app/Traits/HasImage.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\File;
+
+trait HasImage
+{
+    /**
+     * Get the image uuid of the metadata attribute.
+     *
+     * @return string
+     */
+    public function getImageUuidAttribute(): string
+    {
+        return $this->metadata['image'];
+    }
+
+    /**
+     * Get the related image.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function image()
+    {
+        return $this->belongsTo(File::class, 'image_uuid', 'uuid');
+    }
+}


### PR DESCRIPTION
### Description: :
Code refactoring by using `BaseRequest` for applying the same validation rules across multiple requests in our project. This makes the code more efficient and reduces the duplication of code.

Instead of repeating the same rules in every request class, I have created a BaseRequest class and moved the common rules into it. Then I extended this BaseRequest class in all the request classes where those rules are needed.

This way, we can easily change the rules in one place, and they will be applied to all the requests where the BaseRequest is extended. It makes the code more maintainable and helps to reduce the possibility of errors.